### PR TITLE
refactor: refactor error message tests with assert

### DIFF
--- a/app/utils/get-error-message.test.ts
+++ b/app/utils/get-error-message.test.ts
@@ -1,23 +1,26 @@
 /* eslint-disable jest/no-conditional-expect */
 import { describe, expect, it } from 'vitest';
 
+import { assert } from '~/test/assert';
+
 import getErrorMessage from './get-error-message';
 
 describe('getErrorMessage()', () => {
-  it("given an error returns the error's message", () => {
-    const message = 'foo';
-    const error = new Error(message);
+  {
+    const message = 'This is an error message';
 
-    const actual = getErrorMessage(error);
-    const expected = message;
+    assert({
+      given: 'an error',
+      should: "return the error's message",
+      actual: getErrorMessage(new Error(message)),
+      expected: message,
+    });
+  }
 
-    expect(actual).toEqual(expected);
-  });
-
-  it("given a string is thrown return's the string", () => {
+  it('given a string is thrown: returns the string', () => {
     expect.assertions(1);
 
-    const someString = 'some-string';
+    const someString = 'foo';
 
     try {
       throw someString;
@@ -29,7 +32,7 @@ describe('getErrorMessage()', () => {
     }
   });
 
-  it("given a number is thrown return's the number", () => {
+  it('given a number is thrown: returns the number', () => {
     expect.assertions(1);
 
     const someNumber = 1;
@@ -44,7 +47,7 @@ describe('getErrorMessage()', () => {
     }
   });
 
-  it("given extending the custom error class should return the error's message", () => {
+  {
     class CustomError extends Error {
       public constructor(message: string) {
         super(message);
@@ -52,23 +55,25 @@ describe('getErrorMessage()', () => {
     }
 
     const message = 'bar';
-    const error = new CustomError(message);
 
-    const actual = getErrorMessage(error);
-    const expected = message;
+    assert({
+      given: 'an error that extended the custom error class',
+      should: "return the error's message",
+      actual: getErrorMessage(new CustomError(message)),
+      expected: message,
+    });
+  }
 
-    expect(actual).toEqual(expected);
-  });
-
-  it("given a custom error object should return the error's message", () => {
+  {
     const message = 'baz';
-    const error = { message };
 
-    const actual = getErrorMessage(error);
-    const expected = message;
-
-    expect(actual).toEqual(expected);
-  });
+    assert({
+      given: 'a custom error object with a message property',
+      should: "return the object's message property",
+      actual: getErrorMessage({ message }),
+      expected: message,
+    });
+  }
 
   it('handles circular references', () => {
     expect.assertions(1);

--- a/app/utils/get-error-message.ts
+++ b/app/utils/get-error-message.ts
@@ -23,6 +23,35 @@ function toErrorWithMessage(maybeError: unknown): ErrorWithMessage {
   }
 }
 
+/**
+ * Get the error message from an error or any other thing that has been thrown.
+ *
+ * @param error - Something that has been thrown and might be an error.
+ * @returns A string containing the error message.
+ *
+ * @example
+ *
+ * Used on an Error instance:
+ *
+ * ```ts
+ * getErrorMessage(new Error('Something went wrong'))
+ * // ↵ 'Something went wrong'
+ * ```
+ *
+ * Used on a non-error object:
+ *
+ * ```ts
+ * getErrorMessage({ message: 'Something went wrong' })
+ * // ↵ 'Something went wrong'
+ * ```
+ *
+ * Used on a non-error object with no message property (e.g. a primitive):
+ *
+ * ```ts
+ * getErrorMessage('Something went wrong')
+ * // ↵ '"some-string"'
+ * ```
+ */
 export default function getErrorMessage(error: unknown) {
   return toErrorWithMessage(error).message;
 }


### PR DESCRIPTION
Uses assert instead of it and expect for the tests for the get error message utility.

closes #75